### PR TITLE
Fix config requirements in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /coverage
 /config
+# Ignore application configuration
+/config/application.yml

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-require_relative './config/environment'
+require_relative './config'
 require './plant_index'
 require 'figaro/sinatra'
 run Sinatra::Application


### PR DESCRIPTION
Heroku app is giving us a 503 error because it's requiring a file that doesn't exist. Removed this requirement. 