### PR TITLE
Change requirement in config file to plants

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,3 @@
-require './plant_index'
+require './plants'
 require 'figaro/sinatra'
 run Sinatra::Application


### PR DESCRIPTION
Another attempt to troubleshoot heroku deployment error. Change config.rb to require plants instead of plants_index (file no longer exists) 